### PR TITLE
TCHAP: move from AND to + in search query parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ seshat-node/coverage
 .gdb_history
 target
 /Cargo.lock
+
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ bundled-sqlcipher = ["encryption", "rusqlite/bundled-sqlcipher-vendored-openssl"
 
 [dependencies]
 tantivy = "0.13.3"
+# tantivy = "=0.12.0" # Element desktop tantivy version 
 tinysegmenter = "0.1.1"
 rusqlite = "0.31.0"
 fs_extra = "1.2.0"
@@ -34,14 +35,17 @@ rand = { version = "0.8.5", optional = true }
 zeroize = { version = "1.8.1", optional = true }
 byteorder = { version = "1.5.0", optional = true }
 
+# serde_json = "=1.0.61" # Element Desktop serde_json versionn
 serde_json = "1.0.95"
 
 # This is pinned because Tantivy used an serde re-export that turned private in
 # 1.0.119.
 
+serde = { version = "1", default-features = false, features = ["derive"] }
+# Element Desktop serde versionn
 # Relevant serde commit https://github.com/serde-rs/serde/commit/dd1f4b483ee204d58465064f6e5bf5a457543b54
 # Tantivy patch that fixes this issue https://github.com/tantivy-search/tantivy/pull/975
-serde = { version = "1", default-features = false, features = ["derive"] }
+# serde = { version = "=1.0.118", default-features = false, features = ["derive"] }
 thiserror = "1.0.26"
 
 [dev-dependencies]

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -204,7 +204,10 @@ impl IndexSearcher {
 
         let term = if let Some(room) = &config.room_id {
             keys.push(self.room_id_field);
-            format!("+room_id:\"{}\" AND ({})", room, term)
+            // :TCHAP: replace AND by +, starting from tantivy 0.13 the query with AND is described differently, which will affect the score only
+            // By replacing with +, we indicate that the second term is also mandatory, otherwise all the events of the room will be send 
+            // format!("+room_id:\"{}\" AND ({})", room, term)
+            format!("+room_id:\"{}\" +({})", room, term)
         } else if term.is_empty() {
             "*".to_owned()
         } else {


### PR DESCRIPTION
## Changes 
The AND behavior seems to have changed in version 0.13 of tantivy compare to 0.12.
The query doesnt required the AND value to be mandatory and only affect the score
